### PR TITLE
Auto-close issues stalled after owner reply

### DIFF
--- a/.github/workflows/awaiting-response.yml
+++ b/.github/workflows/awaiting-response.yml
@@ -1,0 +1,39 @@
+name: Awaiting Response Label
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    if: ${{ github.event.issue.pull_request == null && github.event.issue.state == 'open' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'awaiting-response';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const commenter = context.payload.comment.user.login;
+            const author = context.payload.issue.user.login;
+
+            if (commenter === 'aziz66' && commenter !== author) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number, labels: [LABEL],
+              });
+              core.info(`Added ${LABEL} (owner replied).`);
+            } else if (commenter === author) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number, name: LABEL,
+                });
+                core.info(`Removed ${LABEL} (author replied).`);
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,28 @@
+name: Close Stale Issues
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 5
+          days-before-close: 2
+          only-issue-labels: 'awaiting-response'
+          stale-issue-label: 'stale'
+          stale-issue-message: |
+            This issue has been waiting on a response for 5 days. It will be closed automatically in 2 days if there's no further activity. Just leave a comment to keep it open.
+          close-issue-message: |
+            Closing this due to inactivity — no response in 7 days after the last reply. Feel free to reopen or open a fresh issue if the problem comes up again.
+          remove-stale-when-updated: true
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
- Adds `awaiting-response.yml` — labels an issue `awaiting-response` when @aziz66 comments, removes it when the issue author replies.
- Adds `close-stale.yml` — scheduled daily via `actions/stale`; 5 days on the label posts a stale warning, 7 days total auto-closes with an inactivity message. Any new activity clears the stale state.
- Both labels (`awaiting-response`, `stale`) have already been created in the repo.

## Test plan
- [ ] After merge to `master`, post a test comment from @aziz66 on a throwaway issue → confirm `awaiting-response` label is added.
- [ ] Have a non-owner reply on the same issue → confirm the label is removed.
- [ ] Trigger `close-stale.yml` manually via **Actions → Close Stale Issues → Run workflow** to verify it dry-runs cleanly without closing anything unintended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)