### PR TITLE
Wire Frame TV navigation keys and hardware volume buttons via local WebSocket

### DIFF
--- a/src/services/televisionService.ts
+++ b/src/services/televisionService.ts
@@ -139,11 +139,19 @@ export class TelevisionService extends BaseService {
     speakerService.setCharacteristic(this.platform.Characteristic.Name, `${this.name} Speaker`);
 
     if (hasVolumeSlider) {
-      // Volume Slider is enabled - TelevisionSpeaker provides NO volume controls to avoid conflicts
-      this.log.info(`🎚️ Volume Slider enabled - TelevisionSpeaker disabled to prevent conflicts for ${this.name}`);
+      // Volume Slider lightbulb provides the in-tile absolute volume slider + mute.
+      // Still expose a RELATIVE TelevisionSpeaker with VolumeSelector so the iOS
+      // hardware volume buttons (in the Apple TV Remote) control TV volume. Using
+      // RELATIVE (no absolute Volume characteristic) avoids conflicting with the slider.
+      this.log.info(`🎚️ Volume Slider enabled - exposing RELATIVE TelevisionSpeaker so hardware volume buttons work for ${this.name}`);
 
-      // Don't register any volume/mute characteristics when volume slider is enabled
-      // This completely avoids conflicts with the separate volume slider accessory
+      speakerService.setCharacteristic(
+        this.platform.Characteristic.VolumeControlType,
+        this.platform.Characteristic.VolumeControlType.RELATIVE,
+      );
+
+      speakerService.getCharacteristic(this.platform.Characteristic.VolumeSelector)
+        .onSet(this.setVolumeSelector.bind(this));
 
     } else {
       // Standard TelevisionSpeaker with full volume/mute controls
@@ -589,6 +597,9 @@ export class TelevisionService extends BaseService {
     // Map HomeKit remote keys to Samsung TV commands
     let command = '';
     let capability = '';
+    // Navigation/control keys have no SmartThings cloud capability; for Frame TVs
+    // they are routed through the local WebSocket (samsung.remote.control) instead.
+    let wsKey = '';
 
     switch (value) {
       case this.platform.Characteristic.RemoteKey.REWIND:
@@ -626,22 +637,48 @@ export class TelevisionService extends BaseService {
         }
         break;
       case this.platform.Characteristic.RemoteKey.ARROW_UP:
+        wsKey = 'KEY_UP';
+        break;
       case this.platform.Characteristic.RemoteKey.ARROW_DOWN:
+        wsKey = 'KEY_DOWN';
+        break;
       case this.platform.Characteristic.RemoteKey.ARROW_LEFT:
+        wsKey = 'KEY_LEFT';
+        break;
       case this.platform.Characteristic.RemoteKey.ARROW_RIGHT:
+        wsKey = 'KEY_RIGHT';
+        break;
       case this.platform.Characteristic.RemoteKey.SELECT:
+        wsKey = 'KEY_ENTER';
+        break;
       case this.platform.Characteristic.RemoteKey.BACK:
+        wsKey = 'KEY_RETURN';
+        break;
       case this.platform.Characteristic.RemoteKey.EXIT:
-        // These would require Samsung's custom remote control capabilities (not in standard SmartThings spec)
-        this.log.debug(`Navigation/control key ${value} - requires Samsung remote control capability (not implemented)`);
-        return;
+        wsKey = 'KEY_EXIT';
+        break;
       case this.platform.Characteristic.RemoteKey.INFORMATION:
-        // Could potentially map to info button (not in standard SmartThings spec)
-        this.log.debug(`Information key pressed for ${this.name} - not in standard capabilities`);
-        return;
+        wsKey = 'KEY_MENU';
+        break;
       default:
         this.log.warn(`Unsupported remote key: ${value} for ${this.name}`);
         return;
+    }
+
+    if (wsKey) {
+      if (!this.samsungWebSocket) {
+        this.log.debug(`Navigation key ${value} ignored for ${this.name} - not a Frame TV with local WebSocket configured`);
+        return;
+      }
+      try {
+        this.log.debug(`Sending navigation key ${wsKey} via local WebSocket for ${this.name}`);
+        await this.samsungWebSocket.clickKey(wsKey);
+        this.log.info(`✅ Remote key ${wsKey} sent via local WebSocket for ${this.name}`);
+      } catch (error) {
+        this.log.error(`Error sending navigation key ${wsKey} via WebSocket for ${this.name}:`, error);
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      return;
     }
 
     if (command && capability) {
@@ -873,6 +910,19 @@ export class TelevisionService extends BaseService {
 
     const command = value === this.platform.Characteristic.VolumeSelector.INCREMENT ? 'volumeUp' : 'volumeDown';
     this.log.debug(`Sending volume selector command: audioVolume.${command} for ${this.name}`);
+
+    // Prefer the Frame TV's local WebSocket for snappy hardware-button response.
+    if (this.samsungWebSocket) {
+      const key = value === this.platform.Characteristic.VolumeSelector.INCREMENT ? 'KEY_VOLUP' : 'KEY_VOLDOWN';
+      try {
+        await this.samsungWebSocket.clickKey(key);
+        this.log.debug(`Volume ${key} sent via local WebSocket for ${this.name}`);
+        setTimeout(() => this.multiServiceAccessory.forceNextStatusRefresh(), 1000);
+        return;
+      } catch (error) {
+        this.log.debug(`Local WebSocket volume key failed for ${this.name}, falling back to cloud: ${error}`);
+      }
+    }
 
     // For Samsung TVs, volumeUp/volumeDown might work better than setVolume
     // These commands don't require specific volume levels and work incrementally


### PR DESCRIPTION
## What

Two improvements for Frame TVs that have local WebSocket control configured (`frameTvDevices`):

1. **Navigation remote keys** — HomeKit `RemoteKey` arrows / Select / Back / Exit / Info were previously no-ops ("not implemented") because SmartThings' cloud API has no directional-key capability. They're now routed through the TV's local `samsung.remote.control` WebSocket via `clickKey()`, so the **Apple TV Remote D-pad in Control Center** drives the TV:
   - `ARROW_UP/DOWN/LEFT/RIGHT` → `KEY_UP/DOWN/LEFT/RIGHT`
   - `SELECT` → `KEY_ENTER`, `BACK` → `KEY_RETURN`, `EXIT` → `KEY_EXIT`, `INFORMATION` → `KEY_MENU`

2. **Hardware volume buttons** — when `registerVolumeSlider` is enabled, the plugin skipped *all* `TelevisionSpeaker` volume characteristics, so the iPhone's physical volume buttons did nothing. It now still exposes a **RELATIVE `TelevisionSpeaker` with `VolumeSelector`** (no absolute `Volume`, so it does not conflict with the volume-slider lightbulb). `VolumeSelector` is routed through the local WebSocket (`KEY_VOLUP`/`KEY_VOLDOWN`) for snappy response, with the existing cloud `audioVolume` command kept as fallback.

## Why

The navigation pad and hardware volume buttons are the parts of the Apple TV Remote users reach for most, and both were silently inert on Frame TVs even though a token-authenticated local WebSocket was already available.

## Notes / safety

- Both behaviors are guarded by `this.samsungWebSocket`; non-Frame TVs and Frames without local config are unaffected (nav keys fall back to the prior no-op, volume falls back to the cloud command).
- No change to the absolute-volume path, so the existing volume-slider lightbulb is untouched.

## Testing

Verified on two 2025 Frame Pro TVs (QE65LS03FA / QE75LS03FW): D-pad navigation, Select/Back/Menu, and iPhone hardware volume buttons all working via the local socket. Note: because these change services on an already-published external accessory, the TV must be removed and re-added in the Home app once to surface the new `VolumeSelector`.
