### PR TITLE
feat: add Samsung robot vacuum support via robotCleanerMovement status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Samsung robot vacuum support** — devices that expose `samsungce.robotCleanerOperatingState` together with `switch` (and typically the `robotCleanerMovement` status) are auto-detected and exposed as a HomeKit `Switch`. Reading the switch reflects whether the vacuum is currently active (`cleaning`, `homing`, or `moving`); setting it on sends `start` and setting it off sends `returnToHome` against the `samsungce.robotCleanerOperatingState` capability. Generic — no device-, model-, or firmware-specific assumptions; works for any Samsung robot vacuum that exposes the capability set.
+
 ## [1.0.67] - Optional SmartThings webhook signature verification
 
 > Stable release of the `1.0.67-beta.0` work (below), validated end-to-end against live SmartThings traffic: with verification enabled, the signed `CONFIRMATION` handshake and live device `EVENT`s are accepted and applied, while unsigned/forged requests are rejected with **HTTP 401**; with the flag off (the default) webhook handling is unchanged. Opt-in and **off by default**, so existing setups are unaffected until they enable it.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Special thanks to each of you for believing in this project.
 - **Automatic device discovery** — devices are added (and removed) as your SmartThings network changes.
 - **UI-based OAuth wizard** — set up authentication from the Homebridge UI without a public tunnel.
 - **Optional real-time webhooks** — push updates from SmartThings for instant device state changes (polling continues as a fallback).
-- **Broad device support** — lights, switches, climate, sensors, locks, security panels, washers/dryers/dishwashers, Samsung TVs (including Frame TVs), multi-zone refrigerators, and more.
+- **Broad device support** — lights, switches, climate, sensors, locks, security panels, washers/dryers/dishwashers, Samsung robot vacuums, Samsung TVs (including Frame TVs), multi-zone refrigerators, and more.
 
 ## Supported Devices
 
@@ -61,7 +61,7 @@ The plugin automatically maps SmartThings capabilities to HomeKit accessories. A
 | **Sensors** | Motion, occupancy, contact, water leak, smoke, CO, illuminance, buttons |
 | **Security Systems** | Arm/disarm panels with live alarm reporting |
 | **Televisions** | Samsung TVs with input picker, volume, app launcher; full Frame TV control |
-| **Appliances** | Washers, dryers, dishwashers, multi-zone Samsung Family Hub refrigerators |
+| **Appliances** | Washers, dryers, dishwashers, Samsung robot vacuums (auto-detected, exposed as a Switch — On = start, Off = return-to-home), multi-zone Samsung Family Hub refrigerators |
 | **Valves** | Smart water valves |
 | **Battery** | Reported as a companion characteristic on supported devices |
 

--- a/src/multiServiceAccessory.ts
+++ b/src/multiServiceAccessory.ts
@@ -31,6 +31,7 @@ import { VolumeSliderService } from './services/volumeSliderService';
 import { WasherService } from './services/washerService';
 import { DryerService } from './services/dryerService';
 import { DishwasherService } from './services/dishwasherService';
+import { RobotVacuumService } from './services/robotVacuumService';
 import { AirPurifierService } from './services/airPurifierService';
 import { SecuritySystemService } from './services/securitySystemService';
 import { RefrigeratorTemperatureService } from './services/refrigeratorTemperatureService';
@@ -189,6 +190,11 @@ export class MultiServiceAccessory {
       capabilities: ['dishwasherOperatingState'],
       optionalCapabilities: ['dishwasherMode', 'remoteControlStatus'],
       service: DishwasherService,
+    },
+    {
+      capabilities: ['samsungce.robotCleanerOperatingState', 'switch'],
+      optionalCapabilities: ['robotCleanerMovement'],
+      service: RobotVacuumService,
     },
     {
       capabilities: ['securitySystem'],

--- a/src/services/robotVacuumService.ts
+++ b/src/services/robotVacuumService.ts
@@ -1,0 +1,85 @@
+import { PlatformAccessory, CharacteristicValue } from 'homebridge';
+import { IKHomeBridgeHomebridgePlatform } from '../platform';
+import { BaseService } from './baseService';
+import { MultiServiceAccessory } from '../multiServiceAccessory';
+import { ShortEvent } from '../webhook/subscriptionHandler';
+
+const ROBOT_COMMAND_CAPABILITY = 'samsungce.robotCleanerOperatingState';
+const ROBOT_MOVEMENT_CAPABILITY = 'robotCleanerMovement';
+const ROBOT_MOVEMENT_ATTRIBUTE = 'robotCleanerMovement';
+// Movement values reported by SmartThings that should map to HomeKit "On".
+const ACTIVE_STATES = ['cleaning', 'homing', 'moving'];
+
+export class RobotVacuumService extends BaseService {
+
+  constructor(platform: IKHomeBridgeHomebridgePlatform, accessory: PlatformAccessory, componentId: string, capabilities: string[],
+    multiServiceAccessory: MultiServiceAccessory,
+    name: string, deviceStatus) {
+    super(platform, accessory, componentId, capabilities, multiServiceAccessory, name, deviceStatus);
+
+    this.setServiceType(platform.Service.Switch);
+    this.log.debug(`Adding RobotVacuumService to ${this.name}`);
+    this.service.getCharacteristic(platform.Characteristic.On)
+      .onGet(this.getSwitchState.bind(this))
+      .onSet(this.setSwitchState.bind(this));
+
+    let pollSwitchesAndLightsSeconds = 10; // default to 10 seconds
+    if (this.platform.config.PollSwitchesAndLightsSeconds !== undefined) {
+      pollSwitchesAndLightsSeconds = this.platform.config.PollSwitchesAndLightsSeconds;
+    }
+
+    if (pollSwitchesAndLightsSeconds > 0) {
+      multiServiceAccessory.startPollingState(pollSwitchesAndLightsSeconds, this.getSwitchState.bind(this), this.service,
+        platform.Characteristic.On);
+    }
+  }
+
+  async setSwitchState(value: CharacteristicValue) {
+    this.log.debug('Received setSwitchState(' + value + ') event for ' + this.name);
+
+    if (!this.multiServiceAccessory.isOnline) {
+      this.log.error(this.name + ' is offline');
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+
+    const command = value ? 'start' : 'returnToHome';
+    this.multiServiceAccessory.sendCommand(this.componentId, ROBOT_COMMAND_CAPABILITY, command).then((success) => {
+      if (success) {
+        this.log.debug('onSet(' + value + ') SUCCESSFUL for ' + this.name + ' (command: ' + command + ')');
+        this.multiServiceAccessory.forceNextStatusRefresh();
+      } else {
+        this.log.error(`Command ${command} failed for ${this.name}`);
+      }
+    });
+  }
+
+  async getSwitchState(): Promise<CharacteristicValue> {
+    this.log.debug('Received getSwitchState() event for ' + this.name);
+
+    return new Promise((resolve, reject) => {
+      this.getStatus().then(success => {
+        if (success) {
+          let movement;
+          try {
+            movement = this.deviceStatus.status[ROBOT_MOVEMENT_CAPABILITY][ROBOT_MOVEMENT_ATTRIBUTE].value;
+          } catch (error) {
+            this.log.error(`Missing robotCleanerMovement from ${this.name}`);
+          }
+          const isActive = ACTIVE_STATES.includes(movement);
+          this.log.debug(`movement from ${this.name}: ${movement} -> HomeKit On = ${isActive}`);
+          resolve(isActive);
+        } else {
+          reject(new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE));
+        }
+      });
+    });
+  }
+
+  public processEvent(event: ShortEvent): void {
+    if (event.capability === ROBOT_MOVEMENT_CAPABILITY && event.attribute === ROBOT_MOVEMENT_ATTRIBUTE) {
+      const isActive = ACTIVE_STATES.includes(event.value);
+      this.log.debug(`Event updating movement for ${this.name} to ${event.value} -> HomeKit On = ${isActive}`);
+      this.service.updateCharacteristic(this.platform.Characteristic.On, isActive);
+    }
+  }
+}


### PR DESCRIPTION
Hi, and thanks for maintaining this plugin — the OAuth wizard and the
per-device handling (Washer→Valve, Frame TV) are really well done.

## Summary
Adds generic Samsung robot vacuum support. Devices exposing
`samsungce.robotCleanerOperatingState` + `switch` (with optional
`robotCleanerMovement`) are auto-detected and exposed as a HomeKit `Switch`.

Currently these devices fall into the generic `SwitchService` path, which
causes two problems: the `switch` capability reports `"on"` whenever the
vacuum is powered/ready (so HomeKit shows it permanently on), and
`switch:off` returns HTTP 422 when the vacuum is docked.

- **Read**: maps `robotCleanerMovement` to On when value ∈ {`cleaning`,
  `homing`, `moving`}. Null/unknown → Off (defensive).
- **Write**: On → `start`, Off → `returnToHome` on
  `samsungce.robotCleanerOperatingState`.
- **Webhook**: `processEvent` updates the Switch live on movement events.
- **Generic**: no device-, model-, or firmware-specific assumptions.

## Why `robotCleanerMovement` and not `operatingState`
On my hardware (Samsung POWERBOT, firmware V114) the
`samsungce.robotCleanerOperatingState.operatingState` attribute proved
unreliable — `null` on the `main` component, and it lags through a
`processing` intermediate before settling on `cleaning`.
`robotCleanerMovement` reports `cleaning`/`charging` consistently and
immediately, so it's the more robust signal. Values may vary across
models/firmwares though — glad to discuss if you've seen otherwise.

## Implementation
- New `src/services/robotVacuumService.ts`, modeled on `switchService.ts`
  (types, imports, logging style).
- New entry in `MultiServiceAccessory.comboCapabilityMap`. The generic
  `SwitchService` path is untouched; the combo's required-capability check
  excludes every non-robot device.
- README + CHANGELOG (Unreleased) updated.

## Verification
- `npm run build` — clean.
- `npm run lint` — 0 errors on the changed files (pre-existing warnings in
  unrelated files unchanged).
- Tested live on a Samsung robot vacuum via Homebridge on Synology DSM:
  status reads and both commands behave as expected.

Happy to adjust naming, structure, or the active-state mapping to fit your
conventions. Thanks!